### PR TITLE
Restore insights verification and harden memo/text utilities

### DIFF
--- a/app/api/bets/route.ts
+++ b/app/api/bets/route.ts
@@ -98,7 +98,7 @@ export async function GET(request: NextRequest) {
     const connection = new Connection(rpcUrl, "confirmed");
     
     // Get treasury address
-    const treasuryAddress = process.env.SOLANA_TREASURY;
+    const treasuryAddress = process.env.SOLANA_TREASURY || process.env.NEXT_PUBLIC_TREASURY;
     if (!treasuryAddress) {
       throw new Error("SOLANA_TREASURY environment variable not set");
     }
@@ -238,7 +238,13 @@ export async function POST(req: NextRequest) {
 
   const rpcUrl = process.env.SOLANA_RPC_URL || "https://api.devnet.solana.com";
   const connection = new Connection(rpcUrl, "confirmed");
-  const treasury = new PublicKey(process.env.SOLANA_TREASURY!);
+  const treasuryKey = process.env.SOLANA_TREASURY || process.env.NEXT_PUBLIC_TREASURY;
+
+  if (!treasuryKey) {
+    return createErrorResponse("CONFIG_ERROR", "Treasury address not configured", 500);
+  }
+
+  const treasury = new PublicKey(treasuryKey);
 
   const tx = await connection.getParsedTransaction(signature, {
     maxSupportedTransactionVersion: 0,

--- a/app/api/insights/_auth.ts
+++ b/app/api/insights/_auth.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { trackServer } from '@/lib/analytics';
-import { checkWalletRateLimit, getWalletIdentifier } from '@/lib/rate-limit-wallet';
+import { checkWalletRateLimit, getWalletIdentifier } from '../../lib/rate-limit-wallet';
 
 interface RateLimit {
   count: number;

--- a/src/server/models/calibration.ts
+++ b/src/server/models/calibration.ts
@@ -201,7 +201,16 @@ export function calculateCalibration(
   }));
   
   const brierScore = calculateBrierScore(brierPredictions);
-  const status = getCalibrationStatus(brierScore);
+  let status = getCalibrationStatus(brierScore);
+
+  if (status === 'Poor' && maturedN > 0) {
+    const variance = brierScore * (1 - brierScore);
+    const margin = Math.sqrt(Math.max(variance, CALIBRATION_CONFIG.EPSILON) / maturedN);
+
+    if (brierScore - margin <= CALIBRATION_CONFIG.BRIER_FAIR) {
+      status = 'Fair';
+    }
+  }
   
   // Create bins if we have enough data
   const bins = maturedN >= CALIBRATION_CONFIG.BINS_MIN_N 


### PR DESCRIPTION
## Summary
- restore the legacy /api/insights GET verification path with memo parsing, rate limiting, and Solana mocks compatibility
- make Solana memo generation tolerant of invalid deadlines and long IDs while keeping payloads under 180 bytes
- harden normalization, text resolver, bet treasury configuration, and calibration status smoothing

## Testing
- npx vitest run app/lib/solana.server.test.ts tests/unit/text-resolver.test.ts
- npx vitest run tests/integration/normalize-api.test.ts tests/unit/memo.test.ts tests/unit/models.calibration.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e264e171108323af0b83ac0ed63a9a